### PR TITLE
Removed manual adding of SP & Facade

### DIFF
--- a/00-Starter-Seed/config/app.php
+++ b/00-Starter-Seed/config/app.php
@@ -162,7 +162,6 @@ return [
         Illuminate\Translation\TranslationServiceProvider::class,
         Illuminate\Validation\ValidationServiceProvider::class,
         Illuminate\View\ViewServiceProvider::class,
-        Auth0\Login\LoginServiceProvider::class,
 
         /*
          * Package Service Providers...
@@ -225,7 +224,6 @@ return [
         'URL' => Illuminate\Support\Facades\URL::class,
         'Validator' => Illuminate\Support\Facades\Validator::class,
         'View' => Illuminate\Support\Facades\View::class,
-        'Auth0' => \Auth0\Login\Facade\Auth0::class,
 
     ],
 

--- a/01-Login/README.md
+++ b/01-Login/README.md
@@ -31,6 +31,15 @@ Otherwise:
 1. [Install Composer](https://getcomposer.org/doc/00-intro.md)
 1. [Run Composer](https://getcomposer.org/doc/01-basic-usage.md)
 
+### Installing Auth0 Plugin
+
+To install Auth0 plugin run `composer require auth0/login:"~5.0"`
+
+This will install:
+
+* The [Auth0 PHP SDK](https://github.com/auth0/auth0-PHP) in `vendor\auth0\auth0-php`
+* The [Auth0 Laravel plugin](https://github.com/auth0/laravel-auth0) in `vendor\auth0\login`
+
 ### Configure the Database (optional) 
 
 If you want to use `mysql` for the example, change settings in `.env` file. The default settings are:

--- a/01-Login/composer.json
+++ b/01-Login/composer.json
@@ -6,7 +6,6 @@
     "type": "project",
     "require": {
         "php": "^7.1.3",
-        "auth0/login": "~5.0",
         "fideloper/proxy": "^4.0",
         "laravel/framework": "^5.5.0",
         "laravel/tinker": "^1.0"

--- a/01-Login/config/app.php
+++ b/01-Login/config/app.php
@@ -150,7 +150,6 @@ return [
         /*
          * Package Service Providers...
          */
-        Auth0\Login\LoginServiceProvider::class,
 
         /*
          * Application Service Providers...
@@ -208,7 +207,6 @@ return [
         'URL' => Illuminate\Support\Facades\URL::class,
         'Validator' => Illuminate\Support\Facades\Validator::class,
         'View' => Illuminate\Support\Facades\View::class,
-        'Auth0' => Auth0\Login\Facade\Auth0::class,
 
     ],
 


### PR DESCRIPTION
With Laravel 5.5 Pacakage AutoDiscovery, manually adding the Auth0 Service Provider and Facade is no more required.

Thus, Removed Auth0 Service Provider and Facade from `config/app.php` of both samples.

In accordance with https://github.com/auth0/docs/pull/6788