### PR TITLE
[SDK-3577] Fix builds: Update Composer plugins allow list

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -92,7 +92,9 @@
     },
     "config": {
         "allow-plugins": {
-          "pestphp/pest-plugin": true
+          "dealerdirect/phpcodesniffer-composer-installer": true,
+          "pestphp/pest-plugin": true,
+          "wikimedia/composer-merge-plugin": true
         },
         "optimize-autoloader": true,
         "preferred-install": "dist",

--- a/app/composer.json
+++ b/app/composer.json
@@ -91,6 +91,9 @@
         }
     },
     "config": {
+        "allow-plugins": {
+          "pestphp/pest-plugin": true
+        },
         "optimize-autoloader": true,
         "preferred-install": "dist",
         "sort-packages": true


### PR DESCRIPTION
This PR updates the composer plugin allow list to fix failing builds.