### PR TITLE
Update post-create-project-cmd in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
             "rm -rf composer.json vendor .github editorconfig gitignore LICENSE sample/README.md",
             "composer install -d sample --no-dev",
             "mv sample/* .",
+            "cp sample/.env.example .env.example",
             "rm -rf sample",
             "curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b ."
         ]


### PR DESCRIPTION
When you run this:
`composer create-project auth0-samples/laravel auth0-laravel-app && cd auth0-laravel-app` the `.env.example` file is not included after running this command.

The `post-create-project-cmd section` in composer.json has been updated to include the copying of the `.env.example` file from the sample directory. This change is necessary to ensure that the `.env.example` file is available in the project's root directory after the installation process.

By adding the following command:
`"cp sample/.env.example .env.example",`

The `.env.example` file is copied from the sample directory to the project's root directory. This allows users to easily reference the example environment file for configuring their application.

This change improves the project setup process and provides a clearer starting point for configuring the environment variables.